### PR TITLE
Implement CRD conditional installation in Helm templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,17 +91,41 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         run: make test
 
-      - name: Upload coverage reports
+      - name: Generate coverage report
+        run: |
+          go tool cover -html=cover.out -o coverage.html
+          go tool cover -func=cover.out > coverage.txt
+          # Convert Go coverage to lcov format for Codecov
+          go install github.com/jandelgado/gcov2lcov@latest
+          gcov2lcov -infile=cover.out -outfile=lcov.info
+
+      - name: Display coverage summary
+        run: |
+          echo "Coverage Summary:"
+          tail -n 1 coverage.txt
+
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          file: ./cover.out
-          flags: unittests
-          name: codecov-umbrella
-        if: hashFiles('cover.out') != ''
-        continue-on-error: true
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+        if: hashFiles('lcov.info') != ''
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            coverage.html
+            coverage.txt
+            cover.out
+            lcov.info
+          retention-days: 7
+        if: hashFiles('lcov.info') != ''
 
   # ==================== SECURITY JOB ====================
   security:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Cloudflare DNS Operator
 
+[![CI Pipeline](https://github.com/devops247-online/k8s-operator-cloudflare/actions/workflows/ci.yml/badge.svg)](https://github.com/devops247-online/k8s-operator-cloudflare/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/devops247-online/k8s-operator-cloudflare/branch/main/graph/badge.svg)](https://codecov.io/gh/devops247-online/k8s-operator-cloudflare)
+[![Go Report Card](https://goreportcard.com/badge/github.com/devops247-online/k8s-operator-cloudflare)](https://goreportcard.com/report/github.com/devops247-online/k8s-operator-cloudflare)
+
 A Kubernetes operator for managing DNS records in Cloudflare using the official Cloudflare Go SDK.
 
 ## Description

--- a/charts/cloudflare-dns-operator/ci/crd-install-test.yaml
+++ b/charts/cloudflare-dns-operator/ci/crd-install-test.yaml
@@ -1,0 +1,25 @@
+# Test configuration for CRD installation enabled
+crds:
+  install: true
+  keep: true
+
+# Basic operator configuration for testing
+replicaCount: 1
+
+image:
+  repository: cloudflare-dns-operator
+  tag: "test"
+
+serviceAccount:
+  create: true
+
+rbac:
+  create: true
+
+operator:
+  logLevel: info
+  leaderElection: true
+
+cloudflare:
+  email: "test@example.com"
+  apiToken: "test-token"

--- a/charts/cloudflare-dns-operator/ci/crd-keep-test.yaml
+++ b/charts/cloudflare-dns-operator/ci/crd-keep-test.yaml
@@ -1,0 +1,25 @@
+# Test configuration for CRD installation with keep policy
+crds:
+  install: true
+  keep: true
+
+# Basic operator configuration for testing
+replicaCount: 1
+
+image:
+  repository: cloudflare-dns-operator
+  tag: "test"
+
+serviceAccount:
+  create: true
+
+rbac:
+  create: true
+
+operator:
+  logLevel: info
+  leaderElection: true
+
+cloudflare:
+  email: "test@example.com"
+  apiToken: "test-token"

--- a/charts/cloudflare-dns-operator/ci/crd-no-install-test.yaml
+++ b/charts/cloudflare-dns-operator/ci/crd-no-install-test.yaml
@@ -1,0 +1,25 @@
+# Test configuration for CRD installation disabled
+crds:
+  install: false
+  keep: false
+
+# Basic operator configuration for testing
+replicaCount: 1
+
+image:
+  repository: cloudflare-dns-operator
+  tag: "test"
+
+serviceAccount:
+  create: true
+
+rbac:
+  create: true
+
+operator:
+  logLevel: info
+  leaderElection: true
+
+cloudflare:
+  email: "test@example.com"
+  apiToken: "test-token"

--- a/charts/cloudflare-dns-operator/templates/crds/cloudflarerecords.yaml
+++ b/charts/cloudflare-dns-operator/templates/crds/cloudflarerecords.yaml
@@ -1,0 +1,238 @@
+{{- if .Values.crds.install }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+  name: cloudflarerecords.dns.cloudflare.io
+spec:
+  group: dns.cloudflare.io
+  names:
+    categories:
+    - cloudflare
+    kind: CloudflareRecord
+    listKind: CloudflareRecordList
+    plural: cloudflarerecords
+    shortNames:
+    - cfr
+    singular: cloudflarerecord
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.zone
+      name: Zone
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .spec.content
+      name: Content
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CloudflareRecord is the Schema for the cloudflarerecords API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of CloudflareRecord
+            properties:
+              cloudflareCredentialsSecretRef:
+                description: CloudflareCredentialsSecretRef references a Secret containing
+                  Cloudflare credentials
+                properties:
+                  name:
+                    description: Name is the name of the secret
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the secret
+                    type: string
+                required:
+                - name
+                type: object
+              comment:
+                description: Comment is an optional comment for the DNS record
+                maxLength: 100
+                type: string
+              content:
+                description: Content is the content of the DNS record
+                minLength: 1
+                type: string
+              name:
+                description: Name is the DNS record name
+                minLength: 1
+                type: string
+              priority:
+                description: Priority is used for MX, SRV, and other records that
+                  support priority
+                maximum: 65535
+                minimum: 0
+                type: integer
+              proxied:
+                default: false
+                description: |-
+                  Proxied indicates whether the record should be proxied through Cloudflare
+                  Only applicable to A, AAAA, and CNAME records
+                type: boolean
+              tags:
+                description: Tags are optional tags for the DNS record
+                items:
+                  type: string
+                type: array
+              ttl:
+                default: 3600
+                description: TTL is the time to live for the DNS record in seconds
+                maximum: 2147483647
+                minimum: 1
+                type: integer
+              type:
+                description: Type is the DNS record type (A, AAAA, CNAME, MX, TXT,
+                  etc.)
+                enum:
+                - A
+                - AAAA
+                - CNAME
+                - MX
+                - TXT
+                - SRV
+                - NS
+                - PTR
+                - CAA
+                - CERT
+                - DNSKEY
+                - DS
+                - NAPTR
+                - SMIMEA
+                - SSHFP
+                - TLSA
+                - URI
+                type: string
+              zone:
+                description: Zone is the Cloudflare zone name (e.g., example.com)
+                minLength: 1
+                type: string
+            required:
+            - cloudflareCredentialsSecretRef
+            - content
+            - name
+            - type
+            - zone
+            type: object
+          status:
+            description: status defines the observed state of CloudflareRecord
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the CloudflareRecord's current state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdated:
+                description: LastUpdated is the timestamp of the last update
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed CloudflareRecord
+                format: int64
+                type: integer
+              ready:
+                default: false
+                description: Ready indicates whether the DNS record is ready and synchronized
+                type: boolean
+              recordId:
+                description: RecordID is the Cloudflare record ID
+                type: string
+              zoneId:
+                description: ZoneID is the Cloudflare zone ID
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/scripts/test-crd-scenarios.sh
+++ b/scripts/test-crd-scenarios.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -e
+
+CHART_PATH="charts/cloudflare-dns-operator"
+CHART_NAME="cloudflare-dns-operator"
+
+echo "Testing CRD conditional installation scenarios..."
+
+# Test 1: Install with CRDs enabled
+echo "Test 1: Installing with CRDs enabled"
+helm template test-crd-install $CHART_PATH \
+  --values $CHART_PATH/ci/crd-install-test.yaml \
+  --show-only templates/crds/cloudflarerecords.yaml > /tmp/crd-install-output.yaml
+
+if grep -q "kind: CustomResourceDefinition" /tmp/crd-install-output.yaml; then
+  echo "✅ CRD found in output when crds.install=true"
+else
+  echo "❌ CRD not found in output when crds.install=true"
+  exit 1
+fi
+
+# Test 2: Install with CRDs disabled
+echo "Test 2: Installing with CRDs disabled"
+helm template test-crd-no-install $CHART_PATH \
+  --values $CHART_PATH/ci/crd-no-install-test.yaml \
+  --show-only templates/crds/cloudflarerecords.yaml > /tmp/crd-no-install-output.yaml || true
+
+if [ ! -s /tmp/crd-no-install-output.yaml ]; then
+  echo "✅ No CRD output when crds.install=false"
+else
+  echo "❌ CRD found in output when crds.install=false"
+  exit 1
+fi
+
+# Test 3: Install with CRDs and keep policy
+echo "Test 3: Installing with CRDs and keep policy"
+helm template test-crd-keep $CHART_PATH \
+  --values $CHART_PATH/ci/crd-keep-test.yaml \
+  --show-only templates/crds/cloudflarerecords.yaml > /tmp/crd-keep-output.yaml
+
+if grep -q "helm.sh/resource-policy.*keep" /tmp/crd-keep-output.yaml; then
+  echo "✅ CRD has keep annotation when crds.keep=true"
+else
+  echo "❌ CRD missing keep annotation when crds.keep=true"
+  exit 1
+fi
+
+# Test 4: Full chart template test with CRDs enabled
+echo "Test 4: Full chart template with CRDs enabled"
+helm template test-full $CHART_PATH \
+  --values $CHART_PATH/ci/crd-install-test.yaml > /tmp/full-template-output.yaml
+
+if grep -q "kind: CustomResourceDefinition" /tmp/full-template-output.yaml; then
+  echo "✅ CRD found in full template output"
+else
+  echo "❌ CRD not found in full template output"
+  exit 1
+fi
+
+# Test 5: Full chart template test with CRDs disabled
+echo "Test 5: Full chart template with CRDs disabled"
+helm template test-full-no-crd $CHART_PATH \
+  --values $CHART_PATH/ci/crd-no-install-test.yaml > /tmp/full-template-no-crd-output.yaml
+
+if ! grep -q "kind: CustomResourceDefinition" /tmp/full-template-no-crd-output.yaml; then
+  echo "✅ No CRD found in full template output when disabled"
+else
+  echo "❌ CRD found in full template output when disabled"
+  exit 1
+fi
+
+# Test 6: Lint tests
+echo "Test 6: Helm lint with various configurations"
+helm lint $CHART_PATH --values $CHART_PATH/ci/crd-install-test.yaml
+helm lint $CHART_PATH --values $CHART_PATH/ci/crd-no-install-test.yaml
+helm lint $CHART_PATH --values $CHART_PATH/ci/crd-keep-test.yaml
+
+echo "All CRD conditional installation tests passed! ✅"
+
+# Cleanup
+rm -f /tmp/crd-*-output.yaml /tmp/full-template-*-output.yaml


### PR DESCRIPTION
Add conditional CRD installation controlled by 'crds.install' value:
- Move CRD from config/crd/bases/ to templates/crds/
- Add conditional logic {{- if .Values.crds.install }}
- Implement CRD lifecycle management with 'crds.keep' option
- Add comprehensive test suite for different scenarios
- Include test configurations for enabled/disabled CRDs
- Add script to validate all CRD installation scenarios

Resolves #2