### PR TITLE
Update Go version to 1.24.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
- Updated Go version from 1.24.5 to 1.24.6 in Dockerfile
- Tested Docker build successfully with new version

## Changes Made
- Modified `Dockerfile` line 2: `FROM golang:1.24.5 AS builder` → `FROM golang:1.24.6 AS builder`

## Test Plan
- [x] Docker build completed successfully
- [x] Pre-commit hooks passed
- [x] No breaking changes expected (patch version update)

## Benefits
- Latest bug fixes and security improvements from Go 1.24.6
- Maintains compatibility while ensuring we use the most recent patch version